### PR TITLE
fix layout shift between blog and about page

### DIFF
--- a/src/app/routes/_index.tsx
+++ b/src/app/routes/_index.tsx
@@ -37,7 +37,7 @@ export default function Index() {
 
       <p className="text-xl">
         Software engineer, previously at Bluesky. These days I'm mostly
-        interested in online safety tooling, ATProtocol, and other social media
+        interested in online safety tooling, AT Protocol, and other social media
         stuff. Sometimes I write about it here.
       </p>
 

--- a/src/app/routes/about.tsx
+++ b/src/app/routes/about.tsx
@@ -18,13 +18,11 @@ export default function About() {
         <h1 className="text-5xl md:text-6xl font-bold text-950">About</h1>
       </div>
 
-      <div className="flex flex-col gap-4 text-xl text-900 leading-relaxed">
-        <p>
-          Software engineer, previously at Bluesky. These days I'm mostly
-          interested in online safety tooling, AT Protocol, and other social
-          media stuff. Sometimes I write about it here.
-        </p>
-      </div>
+      <p className="text-xl">
+        Software engineer, previously at Bluesky. These days I'm mostly
+        interested in online safety tooling, AT Protocol, and other social media
+        stuff. Sometimes I write about it here.
+      </p>
 
       <div className="flex flex-col gap-4">
         <h2 className="text-2xl font-bold text-950">Work</h2>


### PR DESCRIPTION
Hi butterpup

this fixes the layout shift when switching from the "Blog" and "About" page, as well as making the name used for atproto consistent (AT Protocol in both)

arguably i would also remove the "elsewhere" in About since you already link github and bluesky on the top right of the site, seems a bit redundant, but this PR is avoiding any content change

otherwise cool site!!!